### PR TITLE
switched to HTTPS API

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
 :api:
-  :url: http://www.wikidata.org/w/api.php
+  :url: https://www.wikidata.org/w/api.php
 :item:
-  :url: http://www.wikidata.org/wiki/:id
+  :url: https://www.wikidata.org/wiki/:id


### PR DESCRIPTION
(Wikidata no longer supports plain HTTP)
